### PR TITLE
Isolate the DRF integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ is required):
 
 .. code-block:: python
 
-   from urlman import UrlManField
+   from urlman.serializers import UrlManField
 
    class MySerializer(ModelSerializer):
        urls = UrlManField(urls=['view', 'edit'], attribute='urls', full=True)

--- a/test_urlman.py
+++ b/test_urlman.py
@@ -1,5 +1,6 @@
 import pytest
 import urlman
+import urlman.serializers
 
 
 class Post(object):
@@ -127,8 +128,8 @@ def test_callable():
 
 
 def test_rest_framework_serializer(post):
-    field = urlman.UrlManField(urls=["authors", "admin"])
-    relative_field = urlman.UrlManField(urls=["view"], full=False)
+    field = urlman.serializers.UrlManField(urls=["authors", "admin"])
+    relative_field = urlman.serializers.UrlManField(urls=["view"], full=False)
 
     assert field.to_representation(post) == {
         "authors": post.urls.authors.full(),

--- a/urlman/__init__.py
+++ b/urlman/__init__.py
@@ -5,13 +5,6 @@ try:
 except ImportError:  # pragma: no cover
     from urllib.parse import urlunparse
 
-try:
-    from rest_framework.serializers import Field
-except ImportError:  # pragma: no cover
-
-    class Field:
-        pass
-
 
 __version__ = "1.4.0"
 
@@ -170,26 +163,3 @@ class PrintMe(object):
 
     def __str__(self):
         return "{%s}" % self.obj
-
-
-class UrlManField(Field):
-    """Serializer class for Django Restframework."""
-
-    read_only = True
-    write_only = False
-    label = None
-    source = "*"
-
-    def __init__(self, urls, attribute="urls", full=True):
-        self.urls = urls
-        self.url_attribute = attribute
-        self.full = full
-
-    def to_representation(self, value):
-        url_class = getattr(value, self.url_attribute)
-        return {
-            url: getattr(url_class, url).full()
-            if self.full
-            else getattr(url_class, url)
-            for url in self.urls
-        }

--- a/urlman/serializers.py
+++ b/urlman/serializers.py
@@ -1,0 +1,29 @@
+try:
+    from rest_framework.serializers import Field
+except ImportError:  # pragma: no cover
+
+    class Field:
+        pass
+
+
+class UrlManField(Field):
+    """Serializer class for Django Restframework."""
+
+    read_only = True
+    write_only = False
+    label = None
+    source = "*"
+
+    def __init__(self, urls, attribute="urls", full=True):
+        self.urls = urls
+        self.url_attribute = attribute
+        self.full = full
+
+    def to_representation(self, value):
+        url_class = getattr(value, self.url_attribute)
+        return {
+            url: getattr(url_class, url).full()
+            if self.full
+            else getattr(url_class, url)
+            for url in self.urls
+        }


### PR DESCRIPTION
This improves import-time performance by a ton (nearly .3s or 30% in pretalx), which is especially useful for the Django development workflow.

This would introduce a breaking update, because the DRF Serialiser import path changes, but it makes development quite a bit more enjoyable, so it might be worth it? Attached my import timings in pretalx with and without the change. I don't know how many people use this field – GitHub search shows only me (but ofc GitHub isn't everything).

<table>
<tr>
	<td><img src="https://user-images.githubusercontent.com/2657547/120615563-b3f0c900-c458-11eb-899a-484c997299c8.png"> </td>
	<td><img src="https://user-images.githubusercontent.com/2657547/120615573-b6532300-c458-11eb-945d-6bd97ee43f58.png"></td>
</table>
