### PR TITLE
Set attributes used by pydoc/inspect

### DIFF
--- a/urlman/__init__.py
+++ b/urlman/__init__.py
@@ -45,6 +45,9 @@ class Urls(metaclass=UrlsMetaclass):
         self.context = {"self": self.instance}
         self.context.update(self.urls)
         self.__qualname__ = ".".join((klass.__qualname__, name))
+        self.__objclass__ = klass
+        self.__name__ = name
+        self.__wrapped__ = None
 
     def __getattr__(self, attr):
         return self.get_url(attr)


### PR DESCRIPTION
closes #19

Kinda hate having to set `__wrapped__`, but that's what it took to make pydoc happy.