### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint code
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.14"
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 black
+    - name: Lint
+      run: |
+        black --check *.py
+        flake8

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,30 +1,25 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [3.7, 3.11]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v5
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install pytest flake8 black
-    - name: Lint
-      run: |
-        black --check *.py
-        flake8
+        pip install pytest
     - name: Test
-      run: |
-        pytest
+      run: pytest

--- a/urlman/serializers.py
+++ b/urlman/serializers.py
@@ -3,7 +3,8 @@ try:
 except ImportError:  # pragma: no cover
 
     class Field:
-        pass
+        def __init__(self, **kwargs):
+            pass
 
 
 class UrlManField(Field):
@@ -22,8 +23,8 @@ class UrlManField(Field):
     def to_representation(self, value):
         url_class = getattr(value, self.url_attribute)
         return {
-            url: getattr(url_class, url).full()
-            if self.full
-            else getattr(url_class, url)
+            url: (
+                getattr(url_class, url).full() if self.full else getattr(url_class, url)
+            )
             for url in self.urls
         }


### PR DESCRIPTION
CI was broken because 3.7 is not available anymore (we live in the future). I pulled linting and testing apart to have matrix tests. Which is possibly overkill, but otoh I can see the funny metaclass stuff plausibly breaking between versions, so why not.